### PR TITLE
Learntosurf / 2월 3주차 / 2문제 

### DIFF
--- a/_WeeklyChallenges/W12-[DP]/Assignment_BOJ_1520_내리막길.py
+++ b/_WeeklyChallenges/W12-[DP]/Assignment_BOJ_1520_내리막길.py
@@ -4,3 +4,39 @@ https://www.acmicpc.net/problem/1520
 유형: Dynamic Programming, Graph Theory, Graph Traversal, Depth-First Search
 '''
 
+import sys
+sys.setrecursionlimit(10**6)
+input = sys.stdin.readline
+
+# 방향 벡터 (상, 하, 좌, 우)
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+def dfs(x, y):
+    # 도착점에 도달하면 경로 1개 반환
+    if x == M - 1 and y == N - 1:
+        return 1
+    
+    # 이미 방문한 적이 있다면 저장된 경로 개수 반환
+    if dp[x][y] != -1:
+        return dp[x][y]
+
+    # 현재 위치에서 가능한 경로 개수 계산
+    dp[x][y] = 0  # 초기화
+    for i in range(4):
+        nx, ny = x + dx[i], y + dy[i]
+        if 0 <= nx < M and 0 <= ny < N and graph[nx][ny] < graph[x][y]:  # 내리막길 조건
+            dp[x][y] += dfs(nx, ny)
+
+    return dp[x][y]
+
+# 입력 처리
+M, N = map(int, input().split())
+graph = [list(map(int, input().split())) for _ in range(M)]
+
+# DP 배열 (-1로 초기화)
+dp = [[-1] * N for _ in range(M)]
+
+# 결과 출력
+H = dfs(0, 0)
+print(H)

--- a/learntosurf/Dynamic Programming/2025-02-17-[BOJ]-#2169-로봇조종하기.py
+++ b/learntosurf/Dynamic Programming/2025-02-17-[BOJ]-#2169-로봇조종하기.py
@@ -1,0 +1,36 @@
+import sys
+input = sys.stdin.readline
+
+# 입력
+N, M = map(int, input().split()) # 지도의 크기 
+grid = [list(map(int, input().split())) for _ in range(N)] # 각 지역의 가치
+
+# DP 테이블
+dp = [[0] * M for _ in range(N)]
+
+# 첫 번째 행 초기화 (왼쪽에서 오른쪽으로 누적합)
+dp[0][0] = grid[0][0]
+for j in range(1, M):
+    dp[0][j] = dp[0][j-1] + grid[0][j] # (0,1)→(0,2)→(0,3)..
+
+# 두 번째 행부터 (왼쪽에서 오른쪽, 오른쪽에서 왼쪽으로 진행)
+for i in range(1, N):
+    left_to_right = [0] * M
+    right_to_left = [0] * M
+
+    # 왼쪽 → 오른쪽
+    left_to_right[0] = dp[i-1][0] + grid[i][0] # 첫번째 열은 위쪽에서만 올 수 있음 
+    for j in range(1, M): # 두번째 열부터는 위쪽, 왼쪽에서 오는 경우 중 선택
+        left_to_right[j] = max(dp[i-1][j], left_to_right[j-1]) + grid[i][j]
+
+    # 오른쪽 → 왼쪽
+    right_to_left[M-1] = dp[i-1][M-1] + grid[i][M-1] # 마지막 열은 위쪽에서만 올 수 있음 
+    for j in range(M-2, -1, -1): # 그 다음 열부터는 위쪽, 오른쪽에서 오는 경우 중 선택
+        right_to_left[j] = max(dp[i-1][j], right_to_left[j+1]) + grid[i][j]
+
+    # 두 개의 배열을 비교해 dp[i][j] 갱신
+    for j in range(M):
+        dp[i][j] = max(left_to_right[j], right_to_left[j])
+
+# 정답 출력
+print(dp[N-1][M-1]) # 마지막 위치에 저장된 값이 탐사한 지역 가치 합의 최대값

--- a/learntosurf/Dynamic Programming/2025-02-17-[BOJ]-#2169-로봇조종하기.py
+++ b/learntosurf/Dynamic Programming/2025-02-17-[BOJ]-#2169-로봇조종하기.py
@@ -32,5 +32,4 @@ for i in range(1, N):
     for j in range(M):
         dp[i][j] = max(left_to_right[j], right_to_left[j])
 
-# 정답 출력
 print(dp[N-1][M-1]) # 마지막 위치에 저장된 값이 탐사한 지역 가치 합의 최대값

--- a/learntosurf/Dynamic Programming/2025-02-23-[BOJ]-#1520-내리막길.py
+++ b/learntosurf/Dynamic Programming/2025-02-23-[BOJ]-#1520-내리막길.py
@@ -1,0 +1,35 @@
+import sys
+sys.setrecursionlimit(10**6)
+input = sys.stdin.readline
+
+# 방향 벡터 (상, 하, 좌, 우)
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+def dfs(x, y):
+    # 도착점에 도달하면 경로 1개 반환
+    if x == M - 1 and y == N - 1:
+        return 1
+    
+    # 이미 방문한 적이 있다면 저장된 경로 개수 반환
+    if dp[x][y] != -1:
+        return dp[x][y]
+
+    # 현재 위치에서 가능한 경로 개수 계산
+    dp[x][y] = 0  # 초기화
+    for i in range(4):
+        nx, ny = x + dx[i], y + dy[i]
+        if 0 <= nx < M and 0 <= ny < N and graph[nx][ny] < graph[x][y]:  # 내리막길 조건
+            dp[x][y] += dfs(nx, ny)
+
+    return dp[x][y]
+
+# 입력 처리
+M, N = map(int, input().split())
+graph = [list(map(int, input().split())) for _ in range(M)]
+
+# DP 배열 (-1로 초기화)
+dp = [[-1] * N for _ in range(M)]
+
+H = dfs(0, 0)
+print(H)


### PR DESCRIPTION
## 🌱WIL
- DP 문제를 발제하면서 풀이방법을 다시 익힐 수 있었다. 정답 풀이를 보면 쉬워보이는데 풀땐 어려운 DP의 세계...
- 다음주는 꼭 하루에 1문제씩 문제 풀고 정리할것!! 

## 🚀주간 목표 문제 수: 5개
- [백준 #2169. 로봇 조종하기](https://www.acmicpc.net/problem/2169): DP / 골드2
- [백준 #1520. 내리막길](https://www.acmicpc.net/problem/1520): DP / 골드3

---
## [백준 #2169. 로봇 조종하기](https://www.acmicpc.net/problem/2169): DP / 골드2

### 🚩플로우 (선택)
- **DP 테이블 정의**
    `dp[i][j]`: (i,j) 좌표까지 도달할 때 탐사한 지역 가치의 최대 합 
- **DP 점화식 구성 (경로 선택)** 
    어떤 좌표 (i,j)에 도달하는 방법은 세 가지 이다.
    - 위(↓)에서 오는 경우: `dp[i-1][j]`
    - 왼쪽(←)에서 오는 경우: `dp[i][j-1]`
    - 오른쪽(→)에서 오는 경우: `dp[i][j+1]`
    하지만, 한 번 탐사한 지역은 다시 올 수 없으므로, 경로를 구하는 방법이 다르다.
[예제]
- **첫번째 행(`i=0`)은, 왼쪽에서 오른쪽으로 진행하는 경우밖에 없다.** (왔던 칸을 다시 못오기 때문에)
→ 하나씩 값을 누적한 값이 그 칸에 도달하는 최대가치가 된다.
- 나머지 행들은 순서대로 탐색하여 좌표값들을 업데이트한다.
→ 두번째 행(`i=1`)부터는 왼쪽/오른쪽을 나누어 각 좌표의 최대가치를 업데이트할 수 있다.
- 이때, 각 행들은 **두가지 임시배열(왼쪽→오른쪽으로 진행시 구해진 최대값, 오른쪽→왼쪽으로 진행시 구해진 최대값)로 표현한다.**
    - 왼쪽→오른쪽(`left_to_right`): **위**에서 왔을 때와 **왼쪽**에서 왔을 때의 값이 비교되어, 최대값으로 업데이트한다.
        `left_to_right[i][j] = max(dp[i-1][j], left_to_right[i][j-1]) + grid[i][j]`
    - 오른쪽→왼쪽(`right_to_left`): **위**에서 왔을 때의 값과 **오른쪽**에서 왔을 때의 값이 비교되어, 최대값으로 업데이트한다.
        `right_to_left[i][j] = max(dp[i-1][j], right_to_left[i][j+1]) + grid[i][j]`
- 이후, 두 임시배열을 비교함으로써, DP 테이블의 각 좌표를 최대값으로 업데이트 할 수 있다.
    `dp[i][j] = max(left_to_right[j], right_to_left[j])`

### 🚩제출한 코드
```python
import sys
input = sys.stdin.readline

# 입력
N, M = map(int, input().split()) # 지도의 크기 
grid = [list(map(int, input().split())) for _ in range(N)] # 각 지역의 가치

# DP 테이블
dp = [[0] * M for _ in range(N)]

# 첫 번째 행 초기화 (왼쪽에서 오른쪽으로 누적합)
dp[0][0] = grid[0][0]
for j in range(1, M):
    dp[0][j] = dp[0][j-1] + grid[0][j] # (0,1)→(0,2)→(0,3)..

# 두 번째 행부터 (왼쪽에서 오른쪽, 오른쪽에서 왼쪽으로 진행)
for i in range(1, N):
    left_to_right = [0] * M
    right_to_left = [0] * M

    # 왼쪽 → 오른쪽
    left_to_right[0] = dp[i-1][0] + grid[i][0] # 첫번째 열은 위쪽에서만 올 수 있음 
    for j in range(1, M): # 두번째 열부터는 위쪽, 왼쪽에서 오는 경우 중 선택
        left_to_right[j] = max(dp[i-1][j], left_to_right[j-1]) + grid[i][j]

    # 오른쪽 → 왼쪽
    right_to_left[M-1] = dp[i-1][M-1] + grid[i][M-1] # 마지막 열은 위쪽에서만 올 수 있음 
    for j in range(M-2, -1, -1): # 그 다음 열부터는 위쪽, 오른쪽에서 오는 경우 중 선택
        right_to_left[j] = max(dp[i-1][j], right_to_left[j+1]) + grid[i][j]

    # 두 개의 배열을 비교해 dp[i][j] 갱신
    for j in range(M):
        dp[i][j] = max(left_to_right[j], right_to_left[j])

# 정답 출력
print(dp[N-1][M-1]) # 마지막 위치에 저장된 값이 탐사한 지역 가치 합의 최대값
```

### 💡TIL
- DP 테이블을 만들고, (i,j)까지 올 수 있는 최대값을 저장한다.
- 첫번째 행은 왼쪽에서 오른쪽으로만 업데이트한다.
- 두번째 행부터, 3가지 방향(위, 왼쪽, 오른쪽)에서 오는 값을 고려한다.
- 각 행을 왼쪽→오른쪽, 오른쪽→왼쪽 두 번 계산하여 최대값으로 `dp[i][j]`를 갱신한다.
- 마지막 `dp[n-1][m-1]` 값이 정답이 된다.


## [백준 #1520. 내리막길](https://www.acmicpc.net/problem/1520): DP / 골드3

### 🚩플로우 (선택)
- DFS 탐색: 현재 위치에서 상하좌우로 이동하며 높이가 낮은 방향으로만 이동한다.
- 메모이제이션 (DP 적용):
   - dp[x][y] → (x, y)에서 도착점까지 갈 수 있는 경로 개수 저장한다.
   - 1이면 아직 방문하지 않은 상태, 값이 있으면 그대로 사용한다.
- 도착점 도달 시 1 반환, 이후 경로 개수를 dp에 저장하며 중복 연산 방지한다.
- 시간 복잡도: O(NM) → 중복 탐색을 막아 빠른 실행 가능하다.

### 🚩제출한 코드
```python
import sys
sys.setrecursionlimit(10**6)
input = sys.stdin.readline

# 방향 벡터 (상, 하, 좌, 우)
dx = [-1, 1, 0, 0]
dy = [0, 0, -1, 1]

def dfs(x, y):
    # 도착점에 도달하면 경로 1개 반환
    if x == M - 1 and y == N - 1:
        return 1
    
    # 이미 방문한 적이 있다면 저장된 경로 개수 반환
    if dp[x][y] != -1:
        return dp[x][y]

    # 현재 위치에서 가능한 경로 개수 계산
    dp[x][y] = 0  # 초기화
    for i in range(4):
        nx, ny = x + dx[i], y + dy[i]
        if 0 <= nx < M and 0 <= ny < N and graph[nx][ny] < graph[x][y]:  # 내리막길 조건
            dp[x][y] += dfs(nx, ny)

    return dp[x][y]

# 입력 처리
M, N = map(int, input().split())
graph = [list(map(int, input().split())) for _ in range(M)]

# DP 배열 (-1로 초기화)
dp = [[-1] * N for _ in range(M)]

# 결과 출력
H = dfs(0, 0)
print(H)
```

### 💡TIL
- `dp[x][y]`에 결과를 저장해 같은 위치를 다시 계산하지 않도록 한다.
- 깊은 재귀 호출이 필요한 문제에서는 `sys.setrecursionlimit()`을 설정할 수 있다. 