### PR TITLE
Minjeong / 6월 1주차 / 3문제

### DIFF
--- a/minjeong/Heap/2025-06-01-[PGS]-디스크컨트롤러.py
+++ b/minjeong/Heap/2025-06-01-[PGS]-디스크컨트롤러.py
@@ -1,0 +1,29 @@
+import heapq
+
+def solution(jobs):
+    jobs.sort()     # 요청시간 기준 정렬
+    job_len = len(jobs)
+    i = 0           # jobs 인덱스
+    end_time = 0    # 현재 시간
+    return_time = 0 # 작업 반환 시간
+    count = 0       # 작업 처리한 개수
+
+    heap = []
+
+    while count < job_len:
+        # 현재 시간에 요청된 작업 처리
+        while i < job_len and jobs[i][0] <= end_time:
+            heapq.heappush(heap, (jobs[i][1], jobs[i][0], i))  # 소요시간, 요청시간, 작업번호 순서
+            i += 1
+
+        # 대기 큐에 작업이 있다면, 시간을 업데이트한다.
+        if len(heap) > 0:
+            work_time, start_time, num = heapq.heappop(heap)
+            end_time += work_time
+            return_time += end_time - start_time
+            count += 1
+        else:
+            # 대기 큐가 비었다면, 다음 작업이 올 때까지 기다려야 한다.
+            end_time = jobs[i][0]
+
+    return return_time // job_len

--- a/minjeong/Heap/2025-06-02-[백준]-#14698-전생했더니슬라임연구자였던건에대하여(Hard).py
+++ b/minjeong/Heap/2025-06-02-[백준]-#14698-전생했더니슬라임연구자였던건에대하여(Hard).py
@@ -1,0 +1,21 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+T = int(input())
+for _ in range(T):
+    total = 1
+    N = int(input())
+    heap = list(map(int, input().split()))
+    if N == 1:
+        print(1)
+        continue
+
+    heapq.heapify(heap)
+
+    while len(heap) > 1:
+        energy = heapq.heappop(heap) * heapq.heappop(heap)
+        total *= energy
+        heapq.heappush(heap, energy)
+
+    print(total % 1000000007)

--- a/minjeong/Heap/2025-06-06-[백준]-#1715-카드정렬하기.py
+++ b/minjeong/Heap/2025-06-06-[백준]-#1715-카드정렬하기.py
@@ -1,0 +1,16 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+N = int(input())
+cards = [int(input()) for _ in range(N)]
+answer = 0
+heapq.heapify(cards)
+
+while len(cards) > 1:
+    a = heapq.heappop(cards)
+    b = heapq.heappop(cards)
+    answer += a + b
+    heapq.heappush(cards, a+b)
+
+print(answer)


### PR DESCRIPTION
## 🌱WIL
> 이번 한 주의 소감을 작성해주세요!
- 힙, 우선순위 큐를 연습했는데 마침 발제&과제 문제도 우선순위 큐 문제였다. 그래서 덕분에 쉽게 풀이할 수 있었다.

## 🚀주간 목표 문제 수: 3개
> 푼 문제
- [프로그래머스 #42627. 디스크 컨트롤러](https://school.programmers.co.kr/learn/courses/30/lessons/42627?language=python3): 힙 / Level 3
- [백준 #14698. 전생했더니 슬라임 연구자였던 건에 대하여 (Hard)](https://www.acmicpc.net/problem/14698): 힙 / 골드4
- [백준 #1715. 카드 정렬하기](https://www.acmicpc.net/problem/1715): 힙 / 골드4


---
## [프로그래머스 #42627. 디스크 컨트롤러](https://school.programmers.co.kr/learn/courses/30/lessons/42627?language=python3): 힙 / Level 3
정리한 링크: (바로가기)

### 🚩플로우 (선택)
> 코드를 풀이할 때 적었던 플로우가 있나요?
- `jobs`를 요청 시각 기준으로 정렬한다.
- 반복하면서 다음을 수행한다:
    - 현재 시간보다 먼저 들어온 요청을 모두 힙에 넣는다.
    - 힙에서 소요 시간이 가장 짧은 작업을 꺼낸다.
        - 종료 시간(`end_time`)을 갱신하고, 반환 시간을 누적한다.
    - 힙이 비었다면, 다음 요청이 도착할 때까지 기다린다 (`end_time = jobs[i][0]`).

### 🚩제출한 코드
```python
import heapq

def solution(jobs):
    jobs.sort()     # 요청시간 기준 정렬
    job_len = len(jobs)
    i = 0           # jobs 인덱스
    end_time = 0    # 현재 시간
    return_time = 0 # 작업 반환 시간
    count = 0       # 작업 처리한 개수

    heap = []

    while count < job_len:
        # 현재 시간에 요청된 작업 처리
        while i < job_len and jobs[i][0] <= end_time:
            heapq.heappush(heap, (jobs[i][1], jobs[i][0], i))  # 소요시간, 요청시간, 작업번호 순서
            i += 1

        # 대기 큐에 작업이 있다면, 시간을 업데이트한다.
        if len(heap) > 0:
            work_time, start_time, num = heapq.heappop(heap)
            end_time += work_time
            return_time += end_time - start_time
            count += 1
        else:
            # 대기 큐가 비었다면, 다음 작업이 올 때까지 기다려야 한다.
            end_time = jobs[i][0]

    return return_time // job_len
```

### 💡TIL
> 배운 점이 있다면 입력해주세요
이 문제는 단순한 정렬 문제가 아니었다.

시간 흐름에 따른 요청 → 처리 → 대기라는 순환 로직을 **실제 운영체제의 스케줄링처럼 구현**해야 했다.

처음엔 무작정 heap에 넣고 정렬해서 처리하면 될 거라 생각했지만,

시간 조건을 반영하지 않으면 전혀 다른 결과가 나올 수 있다는 걸 배웠다. 나중에 자바로도 풀이해봐야겠다.

또 오랜만에 힙 유형을 풀면서 heapq를 파이썬에서 적용하는 방법에 대해서도 알게 되었다.

https://docs.python.org/ko/3.13/library/heapq.html

https://velog.io/@plate0113/Python-%EC%9A%B0%EC%84%A0%EC%88%9C%EC%9C%84-%ED%81%90-heapq

https://lucky516.tistory.com/5

---
## [백준 #14698. 전생했더니 슬라임 연구자였던 건에 대하여 (Hard)](https://www.acmicpc.net/problem/14698): 힙 / 골드4
정리한 링크: (바로가기)

### 🚩플로우 (선택)
> 코드를 풀이할 때 적었던 플로우가 있나요?
1. 테스트 케이스 수 `T`만큼 반복한다.
2. 슬라임 수 `N`과 슬라임 에너지 리스트를 입력받는다.
3. 슬라임 수가 1이라면 바로 1을 출력한다.
4. 그 외의 경우, 에너지 리스트를 힙으로 구성한다.
5. 힙에서 2개를 꺼내 합성하고, 발생한 에너지를 누적한 뒤 다시 힙에 넣는다.
6. 최종 누적 비용을 모듈러 연산하여 출력한다.

### 🚩제출한 코드
```python
import sys
import heapq
input = sys.stdin.readline

T = int(input())
for _ in range(T):
    total = 1
    N = int(input())
    heap = list(map(int, input().split()))
    if N == 1:
        print(1)
        continue

    heapq.heapify(heap)

    while len(heap) > 1:
        energy = heapq.heappop(heap) * heapq.heappop(heap)
        total *= energy
        heapq.heappush(heap, energy)

    print(total % 1000000007)
```

### 💡TIL
> 배운 점이 있다면 입력해주세요
- 처음에 틀렸던 이유는 `heapq` 모듈을 쓸 때 **리스트를 힙으로 변환하지 않고 `heappop()`을 사용**했기 때문이다.
- `heapq`는 **리스트가 힙 구조일 때만 최소값을 보장**하므로 `heapify()`를 반드시 해줘야 한다.
- 난이도는 골드4이지만, 문제 자체는 **그리디하게 힙을 적용하는 전형적인 유형**이었다.
- 문제 설명이 소설 형식이라 처음에는 이해가 어려웠지만, **핵심은 단순한 연속 곱셈 최적화**이다.
- 다시 한 번, **`heapq`를 사용할 때는 반드시 `heapify()`를 먼저 해주자!**

---
## [백준 #1715. 카드 정렬하기](https://www.acmicpc.net/problem/1715): 힙 / 골드4
정리한 링크: (바로가기)

### 🚩플로우 (선택)
> 코드를 풀이할 때 적었던 플로우가 있나요?

### 🚩제출한 코드
```python
import sys
import heapq
input = sys.stdin.readline

N = int(input())
cards = [int(input()) for _ in range(N)]
answer = 0
heapq.heapify(cards)

while len(cards) > 1:
    a = heapq.heappop(cards)
    b = heapq.heappop(cards)
    answer += a + b
    heapq.heappush(cards, a+b)

print(answer)
```

### 💡TIL
> 배운 점이 있다면 입력해주세요
- 최대한 작은 수를 먼저 묶어야 비교 횟수가 최소가 되는 전략이 필요했다. 이를 위해서는 최소값을 찾는 것에 효율적인 우선순위 큐가 적합하다.
- 우선순위 큐에 대한 구현 연습을 할 수 있는 좋은 연습 문제였다.